### PR TITLE
SS-8087 Pass along "context" to App Builder

### DIFF
--- a/src/modules/configuratormanager/types/loader.ts
+++ b/src/modules/configuratormanager/types/loader.ts
@@ -21,6 +21,14 @@ export interface IConfiguratorLoaderOptions {
      * that may be overridden by the product data.
      */
     baseUrl: string
+
+    /**
+     * Context to be passed to the configurator. Typical values: 
+     *   * undefined (default)
+     *   * "cart" (opened from the cart)
+     *   * "order" (opened from an order)
+     */
+    context?: string
 }
 
 /**

--- a/src/modules/wordpressapi/loader.ts
+++ b/src/modules/wordpressapi/loader.ts
@@ -36,7 +36,7 @@ export class WordPressConfiguratorLoader implements IConfiguratorLoader {
 
 		this.log("🚀 Loading configurator", options);
 		// get product data, or use dummy data for local testing
-		const productId = options.productId;
+		const { productId, context } = options;
 		const productData = this.wordpressApi
 			? await this.wordpressApi.getProductData(parseInt(productId))
 		// in local development mode, use dummy data 
@@ -59,6 +59,7 @@ export class WordPressConfiguratorLoader implements IConfiguratorLoader {
 			slug: productData.slug,
 			modelStateId,
 			settingsUrl: productData.settings_url ? productData.settings_url : this.options.defaultSettingsUrl,
+			context,
 		});
 
 		// do nothing if the URL didn't change

--- a/src/sd-wp.php
+++ b/src/sd-wp.php
@@ -371,7 +371,12 @@ class ShapeDiverConfiguratorPlugin {
         
         if (!empty($model_state_id) && $this->is_product_configurable($product_id)) {
             echo esc_html($product_name);
-            echo '<br><button id="' . esc_attr(SHAPEDIVER_BUTTON_ID) . '" class="' . esc_attr(SHAPEDIVER_CART_ITEM_BUTTON_CLASSES) . '" data-model-state-id="' . esc_attr($model_state_id) . '" data-product-id="' . esc_attr($product_id) . '">' . esc_html(get_option('cart_item_button_label', SHAPEDIVER_CART_ITEM_BUTTON_LABEL)) . '</button>';
+            echo '<br><button id="' . esc_attr(SHAPEDIVER_BUTTON_ID) . '" class="' . esc_attr(SHAPEDIVER_CART_ITEM_BUTTON_CLASSES) . 
+                '" data-model-state-id="' . esc_attr($model_state_id) . 
+                '" data-context=cart' . 
+                ' data-product-id="' . esc_attr($product_id) . '">' . 
+                esc_html(get_option('cart_item_button_label', SHAPEDIVER_CART_ITEM_BUTTON_LABEL)) . 
+                '</button>';
         }
     }
 
@@ -386,7 +391,12 @@ class ShapeDiverConfiguratorPlugin {
         $model_state_id = $item->get_meta('model_state_id');
         
         if (!empty($model_state_id) && $this->is_product_configurable($product_id)) {
-            echo '<button id="' . esc_attr(SHAPEDIVER_BUTTON_ID) . '" class="' . esc_attr(SHAPEDIVER_ORDER_ITEM_BUTTON_CLASSES) . '" data-model-state-id="' . esc_attr($model_state_id) . '" data-product-id="' . esc_attr($product_id) . '">' . esc_html(get_option('order_item_button_label', SHAPEDIVER_ORDER_ITEM_BUTTON_LABEL)) . '</button>';
+            echo '<button id="' . esc_attr(SHAPEDIVER_BUTTON_ID) . '" class="' . esc_attr(SHAPEDIVER_ORDER_ITEM_BUTTON_CLASSES) . 
+                '" data-model-state-id="' . esc_attr($model_state_id) . 
+                '" data-context=order' . 
+                ' data-product-id="' . esc_attr($product_id) . '">' . 
+                esc_html(get_option('order_item_button_label', SHAPEDIVER_ORDER_ITEM_BUTTON_LABEL)) . 
+                '</button>';
         }
     }
 

--- a/src/sd-wp.ts
+++ b/src/sd-wp.ts
@@ -236,13 +236,15 @@ class ConfiguratorManager implements IConfiguratorManager {
 		}
 
 		const modelStateId = target?.dataset.modelStateId;
+		const context = target?.dataset.context;
 
-		this.log(`🔓 Opening configurator for productId "${productId}" modelStateId "${modelStateId}"`);
+		this.log(`🔓 Opening configurator for productId "${productId}" modelStateId "${modelStateId}" context "${context}"`);
 
 		const apiConnector = await this.configuratorLoader.load(this.iframe, {
 			productId,
 			modelStateId,
 			baseUrl: this.baseUrl,
+			context
 		});
 
 		return Promise.resolve(apiConnector);


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8087

Information about the context of opening the configurator is passed to App Builder, allowing the configurator to appear differently when opened from the cart or from an order. We will use a query string variable called context for this. 

Supported values of context:

* not defined (default)
* `cart`
* `order`
* any other string 

